### PR TITLE
リスト5.2で全角閉じカッコが使われてるのを修正する

### DIFF
--- a/5.scala
+++ b/5.scala
@@ -13,7 +13,7 @@ abstract class Polygon(edges: List[Int]) {
   val area: Double
 }
 
-class Triangle(edges: List[Int]） extends Polygon(edges) {
+class Triangle(edges: List[Int]) extends Polygon(edges) {
   val a = edges(0)
   val b = edges(1)
   val c = edges(2)


### PR DESCRIPTION
リスト5.2で全角閉じカッコが使われているのを見つけましたので、修正案を送らせていただきます。